### PR TITLE
Connect frontend auth forms to backend

### DIFF
--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -1,10 +1,26 @@
 import "../assets/icons/index";
-import { Link } from "react-router-dom";
-import AccountPageInput from "../components/AccountPageInput"
-import MainPageLogo from "../assets/Logo.svg"
+import { Link, useNavigate } from "react-router-dom";
+import { useState } from "react";
+import AccountPageInput from "../components/AccountPageInput";
+import MainPageLogo from "../assets/Logo.svg";
 import { GoogleLogo } from "../assets/icons/index";
+import { login, googleLogin } from "../services/authService";
 
 export default function Login() {
+    const [email, setEmail] = useState("");
+    const [password, setPassword] = useState("");
+    const navigate = useNavigate();
+
+    const handleSubmit = async (e) => {
+        e.preventDefault();
+        try {
+            await login(email, password);
+            navigate("/homepage");
+        } catch (err) {
+            console.error(err);
+        }
+    };
+
     return (
         <div className="grid-container">
             <div className="left-grid">
@@ -19,19 +35,19 @@ export default function Login() {
                         <Link to="/signup" className="login-signup-button">Sign up</Link>
                     </div>
 
-                    <Link to="" className="login-google">
+                    <button type="button" className="login-google" onClick={googleLogin}>
                         <img src={GoogleLogo} alt="google-logo" />
                         Sign in with Google account
-                    </Link>
+                    </button>
 
 
-                    <form className="login-form">
+                    <form className="login-form" onSubmit={handleSubmit}>
                         <AccountPageInput
-                            label="Email:" name="username" type="text" placeholder="" required
+                            label="Email:" name="email" type="text" value={email} onChange={(e) => setEmail(e.target.value)} required
                         />
 
                         <AccountPageInput
-                            label="Password:" name="password" type="password" placeholder="" required
+                            label="Password:" name="password" type="password" value={password} onChange={(e) => setPassword(e.target.value)} required
                         />
 
                         <div className="login-forgot-password">

--- a/src/pages/SignUp.jsx
+++ b/src/pages/SignUp.jsx
@@ -1,10 +1,28 @@
 import "../assets/icons/index";
-import { Link } from "react-router-dom";
-import AccountPageInput from "../components/AccountPageInput"
-import MainPageLogo from "../assets/Logo.svg"
+import { Link, useNavigate } from "react-router-dom";
+import { useState } from "react";
+import AccountPageInput from "../components/AccountPageInput";
+import MainPageLogo from "../assets/Logo.svg";
 import { GoogleLogo } from "../assets/icons/index";
+import { register, googleLogin } from "../services/authService";
 
 export default function SignUp() {
+    const [email, setEmail] = useState("");
+    const [password, setPassword] = useState("");
+    const [confirmPassword, setConfirmPassword] = useState("");
+    const navigate = useNavigate();
+
+    const handleSubmit = async (e) => {
+        e.preventDefault();
+        if (password !== confirmPassword) return;
+        try {
+            await register(email, password);
+            navigate("/login");
+        } catch (err) {
+            console.error(err);
+        }
+    };
+
     return (
         <div className="grid-container">
             <div className="left-grid">
@@ -19,26 +37,26 @@ export default function SignUp() {
                         <Link to="" className="signup-signup-button">Sign up</Link>
                     </div>
 
-                    <Link to="" className="signup-google">
+                    <button type="button" className="signup-google" onClick={googleLogin}>
                         <img src={GoogleLogo} alt="google-logo" />
                         Continue with Google account
-                    </Link>
+                    </button>
 
 
-                    <form className="signup-form">
+                    <form className="signup-form" onSubmit={handleSubmit}>
                         <AccountPageInput
-                            label="Email:" name="username" type="text" placeholder="" required
+                            label="Email:" name="email" type="text" value={email} onChange={(e) => setEmail(e.target.value)} required
                         />
 
                         <AccountPageInput
-                            label="Password:" name="password" type="password" placeholder="" required
-                        />
-                    
-                        <AccountPageInput
-                            label="Enter the password again:" name="password" type="password" placeholder="" required
+                            label="Password:" name="password" type="password" value={password} onChange={(e) => setPassword(e.target.value)} required
                         />
 
-                        <AccountPageInput type="submit" value="Sign in" />
+                        <AccountPageInput
+                            label="Enter the password again:" name="passwordConfirm" type="password" value={confirmPassword} onChange={(e) => setConfirmPassword(e.target.value)} required
+                        />
+
+                        <AccountPageInput type="submit" value="Sign up" />
 
                     </form>
 

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -1,0 +1,54 @@
+const API_BASE_URL = 'http://localhost:3000/auth';
+
+export const register = async (email, password) => {
+    const response = await fetch(`${API_BASE_URL}/register`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password })
+    });
+    if (!response.ok) {
+        throw new Error('Registration failed');
+    }
+    return response.json();
+};
+
+export const login = async (email, password) => {
+    const response = await fetch(`${API_BASE_URL}/login`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password })
+    });
+    if (!response.ok) {
+        throw new Error('Login failed');
+    }
+    return response.json();
+};
+
+export const logout = async () => {
+    await fetch(`${API_BASE_URL}/logout`, { method: 'POST', credentials: 'include' });
+};
+
+export const forgotPassword = async (email) => {
+    const response = await fetch(`${API_BASE_URL}/forgot-password`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email })
+    });
+    if (!response.ok) {
+        throw new Error('Failed to send reset email');
+    }
+    return response.json();
+};
+
+export const verifyEmail = async (token) => {
+    const response = await fetch(`${API_BASE_URL}/verify-email/${token}`);
+    if (!response.ok) {
+        throw new Error('Email verification failed');
+    }
+    return response.json();
+};
+
+export const googleLogin = () => {
+    window.location.href = `${API_BASE_URL}/google`;
+};


### PR DESCRIPTION
## Summary
- add auth service to hit `/auth` API
- update login and sign-up pages to call auth API
- revert inadvertent changes to `App` and `Navbar`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_685c1f0c56c88326a097c37fd885ceec